### PR TITLE
Add Instagram link to social media section

### DIFF
--- a/landing-page.tsx
+++ b/landing-page.tsx
@@ -65,6 +65,11 @@ export default function Component() {
                 </svg>
               </a>
             </Button>
+            <Button size="icon" className="bg-green-600 hover:bg-green-700 text-white w-12 h-12 rounded-full" asChild>
+              <a href="https://www.instagram.com/decentralparknyc/" target="_blank" rel="noopener noreferrer" title="Follow on Instagram">
+                <Instagram className="w-5 h-5" />
+              </a>
+            </Button>
           </div>
           <div className="flex items-center justify-center space-x-6 text-green-600">
             <div className="flex items-center space-x-2">

--- a/landing-page.tsx
+++ b/landing-page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Calendar, MapPin, Users, Github, Twitter, Mail, ExternalLink, Send, Copy } from "lucide-react"
+import { Calendar, MapPin, Users, Github, Twitter, Mail, ExternalLink, Send, Copy, Instagram } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import Image from "next/image"
@@ -269,6 +269,15 @@ export default function Component() {
                 className="text-green-600 hover:text-green-800 transition-colors"
               >
                 <Twitter className="w-6 h-6" />
+              </a>
+              <a
+                href="https://www.instagram.com/decentralparknyc/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-green-600 hover:text-green-800 transition-colors"
+                title="Follow on Instagram"
+              >
+                <Instagram className="w-6 h-6" />
               </a>
               <a
                 href="https://github.com/RonTuretzky/decentralparknyc"


### PR DESCRIPTION
Added Instagram link to the footer's social media section. The link opens the @decentralparknyc Instagram profile and follows the same styling and behavior as existing social media links.