### PR TITLE
Add LinkedIn link to social media section

### DIFF
--- a/landing-page.tsx
+++ b/landing-page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Calendar, MapPin, Users, Github, Twitter, Mail, ExternalLink, Send, Copy, Instagram } from "lucide-react"
+import { Calendar, MapPin, Users, Github, Twitter, Mail, ExternalLink, Send, Copy, Instagram, Linkedin } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import Image from "next/image"
@@ -283,6 +283,15 @@ export default function Component() {
                 title="Follow on Instagram"
               >
                 <Instagram className="w-6 h-6" />
+              </a>
+              <a
+                href="https://www.linkedin.com/company/decentral-park/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-green-600 hover:text-green-800 transition-colors"
+                title="Follow on LinkedIn"
+              >
+                <Linkedin className="w-6 h-6" />
               </a>
               <a
                 href="https://github.com/RonTuretzky/decentralparknyc"


### PR DESCRIPTION
Adds the Decentral Park LinkedIn company page link to the footer social media links. The LinkedIn icon is now displayed alongside other social platforms.