### PR TITLE
Fix browser tab title to show Decentral Park

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,8 @@ import type { Metadata } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'v0 App',
-  description: 'Created with v0',
-  generator: 'v0.dev',
+  title: 'Decentral Park',
+  description: 'Decentral Park is a NYC-based progressive tech collective.',
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Replaces the default v0 scaffold metadata with proper branding. The browser tab now shows "Decentral Park" instead of "v0 App", and the description is updated accordingly.